### PR TITLE
Add elm-version to package.json

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,5 +11,6 @@
     ],
     "dependencies": {
         "elm-lang/core": "1.0.0 <= v < 2.0.0"
-    }
+    },
+    "elm-version": "0.15.0 <= v < 0.16.0"
 }


### PR DESCRIPTION
Unable to install

elm-package install --yes evancz/local-channel 1.0.0

Error: Unable to get elm-package.json for evancz/local-channel 1.0.0
Missing field "elm-version", acceptable versions of the Elm Platform (e.g. "0.15.1 <= v < 0.16.0").
    Check out an example elm-package.json file here:
    https://raw.githubusercontent.com/evancz/elm-html/master/elm-package.json
